### PR TITLE
Embrace the unknown

### DIFF
--- a/unknown.go
+++ b/unknown.go
@@ -1,0 +1,25 @@
+package reisen
+
+import (
+	"fmt"
+)
+
+// UnknownStream is a stream containing frames consisting of unknown data.
+type UnknownStream struct {
+	baseStream
+}
+
+// Open is just a stub.
+func (unknown *UnknownStream) Open() error {
+	return nil
+}
+
+// ReadFrame is just a stub.
+func (unknown *UnknownStream) ReadFrame() (Frame, bool, error) {
+	return nil, false, fmt.Errorf("UnknownStream.ReadFrame() not implemented")
+}
+
+// Close is just a stub.
+func (unknown *UnknownStream) Close() error {
+	return nil
+}


### PR DESCRIPTION
The current library can't handle some of the videos that my code needs to process because they also include streams that are neither video nor audio.
I've created an UnknownStream type to prevent the library from dying when these streams are present. Don't try to do anything with unknown streams since it's just a stub that allows processing to continue on the video/audio streams.